### PR TITLE
establish artwork detail framework

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,6 +2,7 @@ import './App.css'
 import Header from './components/Header'
 import Hero from './components/Hero'
 import About from './components/About'
+import ArtworkDetail from './components/ArtworkDetail'
 
 
 function App() {
@@ -11,6 +12,7 @@ function App() {
       <Header />
       <main>
       <Hero />
+      <ArtworkDetail />
       <About />
       </main>
     </>

--- a/src/components/Artwork.jsx
+++ b/src/components/Artwork.jsx
@@ -1,7 +1,0 @@
-import React from 'react'
-
-export default function Artwork() {
-  return (
-    <div>Artwork</div>
-  )
-}

--- a/src/components/ArtworkDetail.jsx
+++ b/src/components/ArtworkDetail.jsx
@@ -1,0 +1,19 @@
+import React from 'react'
+
+export default function ArtworkDetail() {
+
+  const responseData = {
+
+    title:"The Potato Peeler (reverse: Self-Portrait with a Straw Hat)",
+    artist:"Vincent van Gogh",
+    image: "https://images.metmuseum.org/CRDImages/ep/web-large/DT1503.jpg",
+    medium: "Oil on canvas",
+    artYear: "1885",
+    artType: "Painting"
+  };
+
+  return (
+    <><div><h2>{responseData.title}</h2></div><>{responseData.artist}</><><img src={responseData.image} alt="" /></><>{responseData.artYear}</><>Artwork Type: {responseData.artType}</><>{responseData.medium}</></>
+    
+  )
+}

--- a/src/data/testmet.json
+++ b/src/data/testmet.json
@@ -1,0 +1,110 @@
+{
+	"objectID": 459123,
+	"isHighlight": true,
+	"accessionNumber": "1975.1.231",
+	"accessionYear": "1975",
+	"isPublicDomain": true,
+	"primaryImage": "https://images.metmuseum.org/CRDImages/rl/original/DT3154.jpg",
+	"primaryImageSmall": "https://images.metmuseum.org/CRDImages/rl/web-large/DT3154.jpg",
+	"additionalImages": [
+		"https://images.metmuseum.org/CRDImages/rl/original/ep1975.1.231.bw.R.jpg",
+		"https://images.metmuseum.org/CRDImages/rl/original/RLC1.jpg",
+		"https://images.metmuseum.org/CRDImages/rl/original/2489.jpg"
+	],
+	"constituents": [
+		{
+			"constituentID": 161947,
+			"role": "Artist",
+			"name": "Vincent van Gogh",
+			"constituentULAN_URL": "http://vocab.getty.edu/page/ulan/500115588",
+			"constituentWikidata_URL": "https://www.wikidata.org/wiki/Q5582",
+			"gender": ""
+		}
+	],
+	"department": "Robert Lehman Collection",
+	"objectName": "Painting",
+	"title": "Madame Roulin and Her Baby",
+	"culture": "",
+	"period": "",
+	"dynasty": "",
+	"reign": "",
+	"portfolio": "",
+	"artistRole": "Artist",
+	"artistPrefix": "",
+	"artistDisplayName": "Vincent van Gogh",
+	"artistDisplayBio": "Dutch, Zundert 1853–1890 Auvers-sur-Oise",
+	"artistSuffix": "",
+	"artistAlphaSort": "Gogh, Vincent van",
+	"artistNationality": "Dutch",
+	"artistBeginDate": "1853",
+	"artistEndDate": "1890",
+	"artistGender": "",
+	"artistWikidata_URL": "https://www.wikidata.org/wiki/Q5582",
+	"artistULAN_URL": "http://vocab.getty.edu/page/ulan/500115588",
+	"objectDate": "1888",
+	"objectBeginDate": 1888,
+	"objectEndDate": 1888,
+	"medium": "Oil on canvas",
+	"dimensions": "25 × 20 in. (63.5 × 50.8 cm)\r\nFramed: 37 3/8 × 32 in. (94.9 × 81.3 cm)",
+	"measurements": [
+		{
+			"elementName": "Overall",
+			"elementDescription": null,
+			"elementMeasurements": {
+				"Height": 63.5,
+				"Width": 50.8
+			}
+		},
+		{
+			"elementName": "Framed",
+			"elementDescription": null,
+			"elementMeasurements": {
+				"Height": 94.93269,
+				"Width": 81.28016
+			}
+		}
+	],
+	"creditLine": "Robert Lehman Collection, 1975",
+	"geographyType": "",
+	"city": "",
+	"state": "",
+	"county": "",
+	"country": "",
+	"region": "",
+	"subregion": "",
+	"locale": "",
+	"locus": "",
+	"excavation": "",
+	"river": "",
+	"classification": "Paintings",
+	"rightsAndReproduction": "",
+	"linkResource": "",
+	"metadataDate": "2023-10-25T04:55:29.727Z",
+	"repository": "Metropolitan Museum of Art, New York, NY",
+	"objectURL": "https://www.metmuseum.org/art/collection/search/459123",
+	"tags": [
+		{
+			"term": "Infants",
+			"AAT_URL": "http://vocab.getty.edu/page/aat/300189561",
+			"Wikidata_URL": "https://www.wikidata.org/wiki/Q998"
+		},
+		{
+			"term": "Portraits",
+			"AAT_URL": "http://vocab.getty.edu/page/aat/300015637",
+			"Wikidata_URL": "https://www.wikidata.org/wiki/Q134307"
+		},
+		{
+			"term": "Mothers",
+			"AAT_URL": "http://vocab.getty.edu/page/aat/300025932",
+			"Wikidata_URL": "https://www.wikidata.org/wiki/Q7560"
+		},
+		{
+			"term": "Women",
+			"AAT_URL": "http://vocab.getty.edu/page/aat/300025943",
+			"Wikidata_URL": "https://www.wikidata.org/wiki/Q467"
+		}
+	],
+	"objectWikidata_URL": "https://www.wikidata.org/wiki/Q17024776",
+	"isTimelineWork": false,
+	"GalleryNumber": "955"
+}


### PR DESCRIPTION
PR establishes SingleArtwork page that provides details for an artwork:

- Title of work
- Artist name
- image of Artwork
- medium used for artwork
- year artwork was produced
- type of artwork